### PR TITLE
Feat: [COMMON] 엔티티별 soft delete 구현, 기타 기능 수정

### DIFF
--- a/src/main/java/com/example/foodorderplatform/auditing/AuditorAwareImpl.java
+++ b/src/main/java/com/example/foodorderplatform/auditing/AuditorAwareImpl.java
@@ -1,0 +1,22 @@
+package com.example.foodorderplatform.auditing;
+
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(authentication.getName());
+    }
+}

--- a/src/main/java/com/example/foodorderplatform/auditing/Timestamped.java
+++ b/src/main/java/com/example/foodorderplatform/auditing/Timestamped.java
@@ -37,7 +37,11 @@ public abstract class Timestamped {
 	@Temporal(TemporalType.TIMESTAMP)
 	private LocalDateTime deletedAt;
 
-	@LastModifiedBy	// 삭제 시 사용자 자동 저장
 	@Column
 	private String deletedBy;
+
+	public void setDeletedByUser(String username){
+		this.deletedBy = username;
+		this.deletedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/example/foodorderplatform/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/foodorderplatform/config/WebSecurityConfig.java
@@ -26,7 +26,7 @@ public class WebSecurityConfig {
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
-
+    private final String[] permitRequests = {"/api/search/", "/api/user/signup", "/api/login", "/api/store", "api/store/{storeId}"};
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -61,9 +61,7 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((authorizeRequests) ->
                 authorizeRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                        .requestMatchers("/").permitAll()
-                        .requestMatchers("/api/search/").permitAll()
-                        .requestMatchers("/api/user/signup", "/api/login").permitAll()
+                        .requestMatchers(permitRequests).permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/example/foodorderplatform/controller/FoodController.java
+++ b/src/main/java/com/example/foodorderplatform/controller/FoodController.java
@@ -2,17 +2,21 @@ package com.example.foodorderplatform.controller;
 
 import com.example.foodorderplatform.dto.FoodRequestDto;
 import com.example.foodorderplatform.dto.FoodResponseDto;
+import com.example.foodorderplatform.security.UserDetailsImpl;
 import com.example.foodorderplatform.service.FoodService;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,31 +29,69 @@ public class FoodController {
     //음식 관리 페이지 요청
     // 일단 보류
 
-    //음식 생성
+    /**
+     * 음식 생성
+     * @param userDetails 사용자 정보
+     * @param storeId 가게 아이디
+     * @param requestDto 생성할 음식 정보 양식
+     * @return 요청 성공 메세지
+     */
     @PostMapping
-    public ResponseEntity<String> createFood(@PathVariable UUID storeId,
+    public ResponseEntity<String> createFood(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                             @PathVariable UUID storeId,
                                              @RequestBody FoodRequestDto requestDto){
-        return foodService.createFood(storeId, requestDto);
+        return foodService.createFood(storeId, requestDto, userDetails.getUser());
     }
 
-    //음식 목록 조회
+    /**
+     * 음식 목록 조회
+     * @param storeId 가게 아이디
+     * @return 가게 음식 목록 정보
+     */
     @GetMapping
-    public ResponseEntity<List<FoodResponseDto>> getFoodList(@PathVariable UUID storeId){
-        return foodService.getFoodList(storeId);
+    public ResponseEntity<List<FoodResponseDto>> getFoodList(@PathVariable UUID storeId,
+                                                             @RequestParam(defaultValue = "추천") String foodTagName){
+        return foodService.getFoodList(storeId, foodTagName);
     }
-    //음식 단일 조회
+
+    /**
+     * 음식 단일 조회
+     * @param storeId 가게 아이디
+     * @param foodId 음식 아이디
+     * @return 선택 음식 상세 정보
+     */
     @GetMapping("/{foodId}")
     public ResponseEntity<FoodResponseDto> getFood(@PathVariable UUID storeId, @PathVariable UUID foodId){
         return foodService.getFood(storeId, foodId);
     }
-    //음식 수정
+
+    /**
+     * 음식 수정
+     * @param userDetails 사용자 정보
+     * @param storeId 가게 아이디
+     * @param foodId 음식 아이디
+     * @param requestDto 수정할 음식 정보 양식
+     * @return 요청 성공 메세지
+     */
     @PatchMapping("/{foodId}")
-    public ResponseEntity<String> updateFood(@PathVariable UUID storeId,
+    public ResponseEntity<String> updateFood(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                             @PathVariable UUID storeId,
                                              @PathVariable UUID foodId,
                                              @RequestBody FoodRequestDto requestDto){
-        return foodService.updateFood(storeId, foodId, requestDto);
+        return foodService.updateFood(storeId, foodId, requestDto, userDetails.getUser());
     }
 
-    //음식 삭제
-    // 삭제는 soft delete를 해야 해서 추후 구현
+    /**
+     * 음식 삭제
+     * @param userDetails 사용자 정보
+     * @param storeId 가게 아이디
+     * @param foodId 음식 아이디
+     * @return 요청 성공 메세지
+     */
+    @DeleteMapping("/{foodId}")
+    public ResponseEntity<String> deleteFood(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                             @PathVariable UUID storeId,
+                                             @PathVariable UUID foodId){
+        return foodService.deleteFood(storeId, foodId, userDetails.getUser());
+    }
 }

--- a/src/main/java/com/example/foodorderplatform/controller/FoodController.java
+++ b/src/main/java/com/example/foodorderplatform/controller/FoodController.java
@@ -27,71 +27,86 @@ public class FoodController {
     private final FoodService foodService;
 
     //음식 관리 페이지 요청
-    // 일단 보류
-
-    /**
-     * 음식 생성
-     * @param userDetails 사용자 정보
-     * @param storeId 가게 아이디
-     * @param requestDto 생성할 음식 정보 양식
-     * @return 요청 성공 메세지
-     */
-    @PostMapping
-    public ResponseEntity<String> createFood(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                             @PathVariable UUID storeId,
-                                             @RequestBody FoodRequestDto requestDto){
-        return foodService.createFood(storeId, requestDto, userDetails.getUser());
-    }
 
     /**
      * 음식 목록 조회
      * @param storeId 가게 아이디
      * @return 가게 음식 목록 정보
      */
+    @GetMapping("/setting")
+    public ResponseEntity<List<FoodResponseDto>> getFoodSettingInfo(@PathVariable UUID storeId,
+                                                                    @RequestParam(defaultValue = "추천") String foodTagName) {
+        return foodService.getFoodList(storeId, foodTagName);
+    }
+
+    /**
+     * 음식 생성
+     *
+     * @param userDetails 사용자 정보
+     * @param storeId     가게 아이디
+     * @param requestDto  생성할 음식 정보 양식
+     * @return 요청 성공 메세지
+     */
+    @PostMapping
+    public ResponseEntity<String> createFood(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                             @PathVariable UUID storeId,
+                                             @RequestBody FoodRequestDto requestDto) {
+        return foodService.createFood(storeId, requestDto, userDetails.getUser());
+    }
+
+    /**
+     * 음식 목록 조회
+     *
+     * @param storeId 가게 아이디
+     * @return 가게 음식 목록 정보
+     */
     @GetMapping
     public ResponseEntity<List<FoodResponseDto>> getFoodList(@PathVariable UUID storeId,
-                                                             @RequestParam(defaultValue = "추천") String foodTagName){
+                                                             @RequestParam(defaultValue = "추천") String foodTagName) {
         return foodService.getFoodList(storeId, foodTagName);
     }
 
     /**
      * 음식 단일 조회
+     *
      * @param storeId 가게 아이디
-     * @param foodId 음식 아이디
+     * @param foodId  음식 아이디
      * @return 선택 음식 상세 정보
      */
     @GetMapping("/{foodId}")
-    public ResponseEntity<FoodResponseDto> getFood(@PathVariable UUID storeId, @PathVariable UUID foodId){
+    public ResponseEntity<FoodResponseDto> getFood(@PathVariable UUID storeId, @PathVariable UUID foodId) {
         return foodService.getFood(storeId, foodId);
     }
 
     /**
      * 음식 수정
+     *
      * @param userDetails 사용자 정보
-     * @param storeId 가게 아이디
-     * @param foodId 음식 아이디
-     * @param requestDto 수정할 음식 정보 양식
+     * @param storeId     가게 아이디
+     * @param foodId      음식 아이디
+     * @param requestDto  수정할 음식 정보 양식
      * @return 요청 성공 메세지
      */
     @PatchMapping("/{foodId}")
     public ResponseEntity<String> updateFood(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                              @PathVariable UUID storeId,
                                              @PathVariable UUID foodId,
-                                             @RequestBody FoodRequestDto requestDto){
+                                             @RequestBody FoodRequestDto requestDto) {
         return foodService.updateFood(storeId, foodId, requestDto, userDetails.getUser());
     }
 
     /**
      * 음식 삭제
+     *
      * @param userDetails 사용자 정보
-     * @param storeId 가게 아이디
-     * @param foodId 음식 아이디
+     * @param storeId     가게 아이디
+     * @param foodId      음식 아이디
      * @return 요청 성공 메세지
      */
     @DeleteMapping("/{foodId}")
     public ResponseEntity<String> deleteFood(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                              @PathVariable UUID storeId,
-                                             @PathVariable UUID foodId){
+                                             @PathVariable UUID foodId) {
         return foodService.deleteFood(storeId, foodId, userDetails.getUser());
     }
 }

--- a/src/main/java/com/example/foodorderplatform/controller/FoodTagController.java
+++ b/src/main/java/com/example/foodorderplatform/controller/FoodTagController.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,24 +32,24 @@ public class FoodTagController {
      * @return 음식 태그 생성 메세지
      */
     @PostMapping
-    public ResponseEntity<String> createFoodTag(@PathVariable UUID storeId, @RequestBody FoodTagRequestDto requestDto){
-        return foodTagService.createFoodTag(storeId, requestDto);
+    public ResponseEntity<String> createFoodTag(@PathVariable UUID storeId,
+                                                @RequestBody FoodTagRequestDto requestDto,
+                                                @AuthenticationPrincipal UserDetailsImpl userDetails){
+        return foodTagService.createFoodTag(storeId, requestDto, userDetails.getUser());
     }
 
     /**
      * 음식 태그 목록 조회
-     * @param userDetails 사용자 정보
      * @param storeId 가게 아이디
      * @return 음식 태그 목록
      */
     @GetMapping
-    public ResponseEntity<List<FoodTagResponseDto>> getFoodTagList(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                   @PathVariable UUID storeId){
-        return foodTagService.getFoodTagList(userDetails.getUser(), storeId);
+    public ResponseEntity<List<FoodTagResponseDto>> getFoodTagList(@PathVariable UUID storeId){
+        return foodTagService.getFoodTagList(storeId);
     }
 
     /**
-     *
+     * 음식 태그 수정
      * @param userDetails 사용자 정보
      * @param storeId 가게 아이디
      * @param foodTagId 수정할 음식 태그 아이디
@@ -60,6 +61,20 @@ public class FoodTagController {
                                                 @PathVariable UUID storeId,
                                                 @PathVariable UUID foodTagId,
                                                 @RequestBody FoodTagRequestDto requestDto){
-        return foodTagService.updateFoodTag(userDetails.getUser(), storeId, foodTagId, requestDto);
+        return foodTagService.updateFoodTag(storeId, foodTagId, requestDto, userDetails.getUser());
+    }
+
+    /**
+     * 음식 태그 삭제
+     * @param userDetails 사용자 정보
+     * @param storeId 가게 아이디
+     * @param foodTagId 삭제할 음식 태그 아이디
+     * @return 요청 성공 메세지
+     */
+    @DeleteMapping("{foodTagId}")
+    public ResponseEntity<String> deleteFoodTag(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                @PathVariable UUID storeId,
+                                                @PathVariable UUID foodTagId){
+        return foodTagService.deleteFoodTag(storeId, foodTagId, userDetails.getUser());
     }
 }

--- a/src/main/java/com/example/foodorderplatform/controller/StoreController.java
+++ b/src/main/java/com/example/foodorderplatform/controller/StoreController.java
@@ -2,11 +2,14 @@ package com.example.foodorderplatform.controller;
 
 import com.example.foodorderplatform.dto.StoreCreateRequestDto;
 import com.example.foodorderplatform.dto.StoreCreateResponseDto;
+import com.example.foodorderplatform.dto.StoreInfoResponseDto;
+import com.example.foodorderplatform.security.UserDetailsImpl;
 import com.example.foodorderplatform.service.StoreService;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,37 +32,73 @@ public class StoreController {
      * @param storeCreateRequestDto : 가게 개설 정보 입력 양식
      * @return 요청 완료 메세지
      */
-
-    @PostMapping
-    public ResponseEntity<String> createStoreEnterRequest(@RequestBody StoreCreateRequestDto storeCreateRequestDto){
-        return storeService.createStoreEnterRequest(storeCreateRequestDto);
+    @PostMapping("/request")
+    public ResponseEntity<String> createStoreEnterRequest(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                          @RequestBody StoreCreateRequestDto storeCreateRequestDto){
+        return storeService.createStoreEnterRequest(storeCreateRequestDto, userDetails.getUser());
     }
 
     /**
      * 가게 개설 요청 목록 조회
      * @return 가게 개설 요청 목록
+     */
+    @GetMapping("/request")
+    public ResponseEntity<List<StoreCreateResponseDto>> getStoreEnterRequestList(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        return storeService.getStoreEnterRequestList(userDetails.getUser());
+    }
+
+    /**
+     * 가게 개설 요청 목록 조회
+     * @return 가게 개설 요청 목록
+     */
+    @GetMapping("/request/{storeId}")
+    public ResponseEntity<StoreCreateResponseDto> getStoreEnterRequest(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                       @PathVariable UUID storeId){
+        return storeService.getStoreEnterRequest(storeId, userDetails.getUser());
+    }
+
+    /**
+     * 가게 개설 요청 승인
+     * @param userDetails 사용자 정보
+     * @param storeId 가게 아이디
+     * @return 요청 성공 메세지
+     */
+    @PatchMapping("/request/{storeId}")
+    public ResponseEntity<String> confirmStoreEnterRequest(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                           @PathVariable UUID storeId){
+        return storeService.confirmStoreEnterRequest(storeId, userDetails.getUser());
+    }
+
+    /**
+     * 가게 개설 요청 거부
+     * @param userDetails 사용자 정보
+     * @param storeId 가게 아이디
+     * @return 요청 성공 메세지
+     */
+    @DeleteMapping("/request/{storeId}")
+    public ResponseEntity<String> rejectStoreEnterRequest(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                          @PathVariable UUID storeId){
+        return storeService.rejectStoreEnterRequest(storeId, userDetails.getUser());
+    }
+
+    /**
+     * 가게 목록 조회
+     * @param storeCategoryName 가게 카테고리 이름
+     * @return 가게 목록
      */
     @GetMapping
-    public ResponseEntity<List<StoreCreateResponseDto>> getStoreEnterRequestList(){
-        return storeService.getStoreEnterRequestList();
+    public ResponseEntity<List<StoreInfoResponseDto>> getStoreList(@RequestParam(defaultValue = "전체") String storeCategoryName){
+        return storeService.getStoreList(storeCategoryName);
     }
 
     /**
-     * 가게 개설 요청 목록 조회
-     * @return 가게 개설 요청 목록
+     * 가게 단일 조회
+     * 가게 조회 시 하단 음식 정보는 foodController에서 처리
+     * @param storeId 조회할 가게 아이디
+     * @return 조회한 가게 정보
      */
     @GetMapping("/{storeId}")
-    public ResponseEntity<StoreCreateResponseDto> getStoreEnterRequest(@PathVariable UUID storeId){
-        return storeService.getStoreEnterRequest(storeId);
-    }
-
-    @PatchMapping("/{storeId}")
-    public ResponseEntity<String> confirmStoreEnterRequest(@PathVariable UUID storeId){
-        return storeService.confirmStoreEnterRequest(storeId);
-    }
-
-    @DeleteMapping("/{storeId}")
-    public ResponseEntity<String> rejectStoreEnterRequest(@PathVariable UUID storeId){
-        return storeService.rejectStoreEnterRequest(storeId);
+    public ResponseEntity<StoreInfoResponseDto> getStore(@PathVariable UUID storeId){
+        return storeService.getStore(storeId);
     }
 }

--- a/src/main/java/com/example/foodorderplatform/controller/UserController.java
+++ b/src/main/java/com/example/foodorderplatform/controller/UserController.java
@@ -45,7 +45,6 @@ public class UserController {
         return userService.signup(requestDto);
     }
 
-
     /**
      * 마이 페이지 유저 정보 조회
      * @return 마이페이지
@@ -64,7 +63,4 @@ public class UserController {
     public ResponseEntity<UserInfoResponseDto> updateUserInfo(@RequestBody UserInfoRequestDto requestDto){
         return userService.updateUserInfo(requestDto);
     }
-
-
-
 }

--- a/src/main/java/com/example/foodorderplatform/dto/StoreCreateRequestDto.java
+++ b/src/main/java/com/example/foodorderplatform/dto/StoreCreateRequestDto.java
@@ -21,6 +21,7 @@ public class StoreCreateRequestDto {
     private String ingredientOrigin;	// 원산지
     private String regionName;          // 지역 이름
     private String addressName;         // 상세 주소
+    private String storeCategoryName;   // 가게 카테고리 이름
     private BusinessInfoDto businessInfoDto;
 
 }

--- a/src/main/java/com/example/foodorderplatform/dto/StoreInfoResponseDto.java
+++ b/src/main/java/com/example/foodorderplatform/dto/StoreInfoResponseDto.java
@@ -1,0 +1,32 @@
+package com.example.foodorderplatform.dto;
+
+import com.example.foodorderplatform.entity.Store;
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StoreInfoResponseDto {
+
+    private UUID id;                    // 가게 아이디
+    private String storeName;			// 가게 이름
+    private Boolean storeState;			// 운영상태
+    private String storeRestDay;		// 휴무일
+    private String storeImg;			// 가게 이미지
+    private String storeDescription;	// 가게 소개
+    private LocalTime storeOpenHour;	// 가게 오픈 시간
+    private LocalTime storeCloseHour;	// 가게 마감 시간
+    private String ingredientOrigin;	// 원산지
+
+    public StoreInfoResponseDto(Store store){
+        this.id = store.getId();
+        this.storeName = store.getStoreName();
+        this.storeState = store.getStoreState();
+        this.storeDescription = store.getStoreDescription();
+        this.storeOpenHour = store.getStoreOpenHour();
+        this.storeCloseHour = store.getStoreCloseHour();
+        this.ingredientOrigin = store.getIngredientOrigin();
+    }
+}

--- a/src/main/java/com/example/foodorderplatform/entity/AiScript.java
+++ b/src/main/java/com/example/foodorderplatform/entity/AiScript.java
@@ -22,7 +22,7 @@ public class AiScript extends Timestamped {
 	@Column
 	private String scriptAnswer;	// 스크립트 답변
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 }

--- a/src/main/java/com/example/foodorderplatform/entity/BusinessInfo.java
+++ b/src/main/java/com/example/foodorderplatform/entity/BusinessInfo.java
@@ -27,7 +27,7 @@ public class BusinessInfo {
 	private String ownerName;					// 대표자명
 
 	// 가게와의 연관 관계
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id")
 	private Store store;
 

--- a/src/main/java/com/example/foodorderplatform/entity/Cart.java
+++ b/src/main/java/com/example/foodorderplatform/entity/Cart.java
@@ -14,12 +14,12 @@ public class Cart {
 	private UUID id;
 
 	// 가게와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id")
 	private Store store;
 
 	// 사용자와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 }

--- a/src/main/java/com/example/foodorderplatform/entity/Food.java
+++ b/src/main/java/com/example/foodorderplatform/entity/Food.java
@@ -40,7 +40,7 @@ public class Food extends Timestamped {
 
 	// 메뉴 태그와의 연관 관계
 	@ManyToOne
-	@JoinColumn(name = "menu_tag_id")
+	@JoinColumn(name = "food_tag_id")
 	private FoodTag foodTag;
 
 	public Food(Store store, FoodTag foodTag, FoodRequestDto requestDto){

--- a/src/main/java/com/example/foodorderplatform/entity/FoodCart.java
+++ b/src/main/java/com/example/foodorderplatform/entity/FoodCart.java
@@ -18,11 +18,11 @@ public class FoodCart {
 	@Column(nullable = false)
 	private Integer foodCnt;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "cart_id")
 	private Cart cart;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "food_id")
 	private Food food;
 }

--- a/src/main/java/com/example/foodorderplatform/entity/FoodCategory.java
+++ b/src/main/java/com/example/foodorderplatform/entity/FoodCategory.java
@@ -20,7 +20,7 @@ public class FoodCategory {
 	private String categoryName;
 
 	// 음식과의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "food_id")
 	private Food food;
 }

--- a/src/main/java/com/example/foodorderplatform/entity/FoodOrder.java
+++ b/src/main/java/com/example/foodorderplatform/entity/FoodOrder.java
@@ -19,12 +19,12 @@ public class FoodOrder {
 	private Integer foodCnt;	// 음식개수
 
 	// 주문과의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "order_id")
 	private Order order;
 
 	// 음식과의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "food_id")
 	private Food food;
 }

--- a/src/main/java/com/example/foodorderplatform/entity/FoodTag.java
+++ b/src/main/java/com/example/foodorderplatform/entity/FoodTag.java
@@ -1,5 +1,6 @@
 package com.example.foodorderplatform.entity;
 
+import com.example.foodorderplatform.auditing.Timestamped;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "p_food_tag")
 @NoArgsConstructor
-public class FoodTag {
+public class FoodTag extends Timestamped {
 	@Id
 	@GeneratedValue(strategy=GenerationType.UUID)
 	private UUID id;
@@ -20,7 +21,7 @@ public class FoodTag {
 	private String foodTagName;
 
 	// 가게와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id")
 	private Store store;
 

--- a/src/main/java/com/example/foodorderplatform/entity/Order.java
+++ b/src/main/java/com/example/foodorderplatform/entity/Order.java
@@ -30,16 +30,16 @@ public class Order extends Timestamped {
 	private String orderRequest;			// 주문 요청사항
 
 	// 유저와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 
 	// 가게와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id")
 	private Store store;
 
 	// 결제와의 연관 관계
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private Payment payment;
 }

--- a/src/main/java/com/example/foodorderplatform/entity/Payment.java
+++ b/src/main/java/com/example/foodorderplatform/entity/Payment.java
@@ -27,12 +27,12 @@ public class Payment extends Timestamped {
 	private Long paymentPrice;
 
 	// 주문과의 연관 관계
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "order_id")
 	private Order order;
 
 	// 사용자와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 }

--- a/src/main/java/com/example/foodorderplatform/entity/Review.java
+++ b/src/main/java/com/example/foodorderplatform/entity/Review.java
@@ -25,17 +25,17 @@ public class Review extends Timestamped {
 	private String reviewContent;
 
 	// 음식과의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "food_id")
 	private Food food;
 
 	// 사용자와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 
 	// 가게와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id")
 	private Store store;
 }

--- a/src/main/java/com/example/foodorderplatform/entity/Store.java
+++ b/src/main/java/com/example/foodorderplatform/entity/Store.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -53,27 +54,27 @@ public class Store extends Timestamped {
 	private StoreConfirmStatus confirmStatus;
 
 	// 유저와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 
 	// 가게 카테고리와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_category_id")
 	private StoreCategory storeCategory;
 
 	// 지역과의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "region_id")
 	private Region region;
 
 	// 주소와의 연관 관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "address_id")
 	private Address address;
 
 	// 사업자 등록증 정보와의 관계
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	private BusinessInfo businessInfo;
 
 	public Store(User user, Region region, Address address, StoreCreateRequestDto requestDto, BusinessInfo businessInfo){

--- a/src/main/java/com/example/foodorderplatform/entity/StoreCategory.java
+++ b/src/main/java/com/example/foodorderplatform/entity/StoreCategory.java
@@ -18,5 +18,5 @@ public class StoreCategory {
 	private UUID id;
 
 	@Column(nullable = false)
-	private String categoryName;	// 카테고리 이름
+	private String storeCategoryName;	// 카테고리 이름
 }

--- a/src/main/java/com/example/foodorderplatform/entity/User.java
+++ b/src/main/java/com/example/foodorderplatform/entity/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -51,12 +52,12 @@ public class User extends Timestamped {
 	private UserRoleEnum role;
 
 	// 지역과의 연관관계
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "region_id")
 	private Region region;
 
 	// 주소와의 연관관계
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "address_id")
 	private Address address;
 

--- a/src/main/java/com/example/foodorderplatform/message/SuccessMessage.java
+++ b/src/main/java/com/example/foodorderplatform/message/SuccessMessage.java
@@ -10,8 +10,10 @@ public enum SuccessMessage {
     SIGNUP_SUCCESS("회원가입이 완료되었습니다."),
     CREATE_FOOD_SUCCESS("음식 생성이 완료되었습니다."),
     UPDATE_FOOD_SUCCESS("음식 수정이 완료되었습니다."),
+    DELETE_FOOD_SUCCESS("음식 삭제가 완료되었습니다."),
     CREATE_FOOD_TAG_SUCCESS("음식 태그 생성이 완료되었습니다."),
-    UPDATE_FOOD_TAG_SUCCESS("음식 태그 수정이 완료되었습니다.");
+    UPDATE_FOOD_TAG_SUCCESS("음식 태그 수정이 완료되었습니다."),
+    DELETE_FOOD_TAG_SUCCESS("음식 태그 삭제가 완료되었습니다.");
     private final String message;
 
     SuccessMessage(String message){

--- a/src/main/java/com/example/foodorderplatform/repository/FoodRepository.java
+++ b/src/main/java/com/example/foodorderplatform/repository/FoodRepository.java
@@ -8,5 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FoodRepository extends JpaRepository<Food, UUID> {
 
     List<Food> findAllByStore_Id(UUID storeId);
+    void deleteById(UUID id);
+    List<Food> findAllByStore_IdAndRecommandIsTrue(UUID storeId, Boolean recommand);
 
 }

--- a/src/main/java/com/example/foodorderplatform/repository/FoodRepository.java
+++ b/src/main/java/com/example/foodorderplatform/repository/FoodRepository.java
@@ -9,6 +9,6 @@ public interface FoodRepository extends JpaRepository<Food, UUID> {
 
     List<Food> findAllByStore_Id(UUID storeId);
     void deleteById(UUID id);
-    List<Food> findAllByStore_IdAndRecommandIsTrue(UUID storeId, Boolean recommand);
+    List<Food> findAllByStore_IdAndRecommand(UUID storeId, boolean recommand);
 
 }

--- a/src/main/java/com/example/foodorderplatform/repository/FoodTagRepository.java
+++ b/src/main/java/com/example/foodorderplatform/repository/FoodTagRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FoodTagRepository extends JpaRepository<FoodTag, UUID> {
     FoodTag findByFoodTagName(String foodTagName);
+    FoodTag findByStore_IdAndFoodTagName(UUID storeId, String foodTagName);
     List<FoodTag> findAllByStore_Id(UUID storeId);
 }

--- a/src/main/java/com/example/foodorderplatform/repository/FoodTagRepository.java
+++ b/src/main/java/com/example/foodorderplatform/repository/FoodTagRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FoodTagRepository extends JpaRepository<FoodTag, UUID> {
     FoodTag findByFoodTagName(String foodTagName);
     FoodTag findByStore_IdAndFoodTagName(UUID storeId, String foodTagName);
-    List<FoodTag> findAllByStore_Id(UUID storeId);
+    List<FoodTag> findAllByStore_IdAndDeletedAtNull(UUID storeId);
 }

--- a/src/main/java/com/example/foodorderplatform/repository/StoreRepository.java
+++ b/src/main/java/com/example/foodorderplatform/repository/StoreRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
-    List<Store> findAllByConfirmStatus(StoreConfirmStatus required);
-    List<Store> findAllByStoreCategory_StoreCategoryName(String storeCategoryName);
+    List<Store> findAllByDeletedAtIsNull();
+    List<Store> findAllByConfirmStatusAndDeletedAtIsNull(StoreConfirmStatus required);
+    List<Store> findAllByDeletedAtIsNullAndStoreCategory_StoreCategoryName(String storeCategoryName);
 }

--- a/src/main/java/com/example/foodorderplatform/repository/StoreRepository.java
+++ b/src/main/java/com/example/foodorderplatform/repository/StoreRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
     List<Store> findAllByConfirmStatus(StoreConfirmStatus required);
+    List<Store> findAllByStoreCategory_StoreCategoryName(String storeCategoryName);
 }

--- a/src/main/java/com/example/foodorderplatform/service/FoodService.java
+++ b/src/main/java/com/example/foodorderplatform/service/FoodService.java
@@ -1,7 +1,9 @@
 package com.example.foodorderplatform.service;
 
+import static com.example.foodorderplatform.message.ExceptionMessage.*;
 import static com.example.foodorderplatform.message.ExceptionMessage.FOOD_NOT_FOUND;
 import static com.example.foodorderplatform.message.ExceptionMessage.STORE_NOT_FOUND;
+import static com.example.foodorderplatform.message.SuccessMessage.*;
 import static com.example.foodorderplatform.message.SuccessMessage.CREATE_FOOD_SUCCESS;
 import static com.example.foodorderplatform.message.SuccessMessage.UPDATE_FOOD_SUCCESS;
 
@@ -10,9 +12,11 @@ import com.example.foodorderplatform.dto.FoodResponseDto;
 import com.example.foodorderplatform.entity.Food;
 import com.example.foodorderplatform.entity.FoodTag;
 import com.example.foodorderplatform.entity.Store;
+import com.example.foodorderplatform.entity.User;
 import com.example.foodorderplatform.repository.FoodRepository;
 import com.example.foodorderplatform.repository.FoodTagRepository;
 import com.example.foodorderplatform.repository.StoreRepository;
+import com.example.foodorderplatform.util.UserValidator;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -30,33 +34,58 @@ public class FoodService {
     private final FoodRepository foodRepository;
     private final FoodTagRepository foodTagRepository;
 
-    public ResponseEntity<String> createFood(UUID storeId, FoodRequestDto requestDto) {
+    // 음식 생성
+    public ResponseEntity<String> createFood(UUID storeId, FoodRequestDto requestDto, User user) {
         Store store = findStoreById(storeId);
+        if (!UserValidator.validateRoleUpperManager(user) || !UserValidator.validateIsStoreOwner(store, user)){
+            throw new IllegalArgumentException(USER_UNAUTHORIZED.getMessage());
+        }
         FoodTag foodTag = findFoodTagByFoodTagName(requestDto.getFoodTagName());
         foodRepository.save(new Food(store, foodTag, requestDto));
         return new ResponseEntity<>(CREATE_FOOD_SUCCESS.getMessage(), HttpStatus.OK);
     }
 
-    public ResponseEntity<List<FoodResponseDto>> getFoodList(UUID storeId) {
-        List<Food> foodList = foodRepository.findAllByStore_Id(storeId);
+    // 음식 목록 조회
+    public ResponseEntity<List<FoodResponseDto>> getFoodList(UUID storeId, String foodTagName) {
+        List<Food> foodList;
+        if (foodTagName.equals("추천")){
+            foodList = foodRepository.findAllByStore_IdAndRecommandIsTrue(storeId, true);
+        } else {
+            FoodTag foodTag = foodTagRepository.findByStore_IdAndFoodTagName(storeId, foodTagName);
+            foodList = foodTag.getFoodList();
+        }
         List<FoodResponseDto> foodResponseDtoList = foodList.stream().map(FoodResponseDto::new).toList();
         return new ResponseEntity<>(foodResponseDtoList, HttpStatus.OK);
     }
 
+    // 음식 단일 조회
     public ResponseEntity<FoodResponseDto> getFood(UUID storeId, UUID foodId) {
         Store store = findStoreById(storeId);
         Food food = findFoodById(foodId);
         return new ResponseEntity<>(new FoodResponseDto(food), HttpStatus.OK);
     }
 
-    public ResponseEntity<String> updateFood(UUID storeId, UUID foodId, FoodRequestDto requestDto) {
+    // 음식 수정
+    public ResponseEntity<String> updateFood(UUID storeId, UUID foodId, FoodRequestDto requestDto, User user) {
         Store store = findStoreById(storeId);
+        if (!UserValidator.validateRoleUpperManager(user) || !UserValidator.validateIsStoreOwner(store, user)){
+            throw new IllegalArgumentException(USER_UNAUTHORIZED.getMessage());
+        }
         Food food = findFoodById(foodId);
         FoodTag foodTag = foodTagRepository.findByFoodTagName(requestDto.getFoodTagName());
         food.updateFood(foodTag, requestDto);
         return new ResponseEntity<>(UPDATE_FOOD_SUCCESS.getMessage(), HttpStatus.OK);
     }
 
+    public ResponseEntity<String> deleteFood(UUID storeId, UUID foodId, User user) {
+        Store store = findStoreById(storeId);
+        if (!UserValidator.validateIsStoreOwner(store, user)){
+            throw new IllegalArgumentException(USER_UNAUTHORIZED.getMessage());
+        }
+        Food food = findFoodById(foodId);
+        food.setDeletedByUser(user.getUserName());
+        return new ResponseEntity<>(DELETE_FOOD_SUCCESS.getMessage(),HttpStatus.OK);
+    }
     /*
     ---------------------------------------- [private 메서드] -------------------------------------------
      */

--- a/src/main/java/com/example/foodorderplatform/service/FoodService.java
+++ b/src/main/java/com/example/foodorderplatform/service/FoodService.java
@@ -49,7 +49,7 @@ public class FoodService {
     public ResponseEntity<List<FoodResponseDto>> getFoodList(UUID storeId, String foodTagName) {
         List<Food> foodList;
         if (foodTagName.equals("추천")){
-            foodList = foodRepository.findAllByStore_IdAndRecommandIsTrue(storeId, true);
+            foodList = foodRepository.findAllByStore_IdAndRecommand(storeId, true);
         } else {
             FoodTag foodTag = foodTagRepository.findByStore_IdAndFoodTagName(storeId, foodTagName);
             foodList = foodTag.getFoodList();

--- a/src/main/java/com/example/foodorderplatform/service/FoodTagService.java
+++ b/src/main/java/com/example/foodorderplatform/service/FoodTagService.java
@@ -42,7 +42,7 @@ public class FoodTagService {
 
     // 목록 조회
     public ResponseEntity<List<FoodTagResponseDto>> getFoodTagList(UUID storeId) {
-        List<FoodTag> foodTagList = foodTagRepository.findAllByStore_Id(storeId);
+        List<FoodTag> foodTagList = foodTagRepository.findAllByStore_IdAndDeletedAtNull(storeId);
         List<FoodTagResponseDto> foodTagResponseDtoList = foodTagList.stream().map(FoodTagResponseDto::new).toList();
         return new ResponseEntity<>(foodTagResponseDtoList, HttpStatus.OK);
     }

--- a/src/main/java/com/example/foodorderplatform/service/StoreService.java
+++ b/src/main/java/com/example/foodorderplatform/service/StoreService.java
@@ -64,7 +64,7 @@ public class StoreService {
         if (!UserValidator.validateRoleUpperManager(user)){
             throw new IllegalArgumentException(USER_UNAUTHORIZED.getMessage());
         }
-        List<Store> storeList = storeRepository.findAllByConfirmStatus(StoreConfirmStatus.REQUIRED);
+        List<Store> storeList = storeRepository.findAllByConfirmStatusAndDeletedAtIsNull(StoreConfirmStatus.REQUIRED);
         List<StoreCreateResponseDto> storeCreateResponseDtoList = storeList.stream().map(StoreCreateResponseDto::new).toList();
         return new ResponseEntity<>(storeCreateResponseDtoList, HttpStatus.OK);
     }
@@ -103,9 +103,9 @@ public class StoreService {
     public ResponseEntity<List<StoreInfoResponseDto>> getStoreList(String storeCategoryName) {
         List<Store> storeList;
         if (storeCategoryName.equals("전체")){
-            storeList = storeRepository.findAll();
+            storeList = storeRepository.findAllByDeletedAtIsNull();
         } else {
-            storeList = storeRepository.findAllByStoreCategory_StoreCategoryName(storeCategoryName);
+            storeList = storeRepository.findAllByDeletedAtIsNullAndStoreCategory_StoreCategoryName(storeCategoryName);
         }
         List<StoreInfoResponseDto> storeInfoResponseDtoList = storeList.stream().map(StoreInfoResponseDto::new).toList();
         return new ResponseEntity<>(storeInfoResponseDtoList, HttpStatus.OK);

--- a/src/main/java/com/example/foodorderplatform/service/StoreService.java
+++ b/src/main/java/com/example/foodorderplatform/service/StoreService.java
@@ -101,8 +101,12 @@ public class StoreService {
 
     // 가게 목록 조회
     public ResponseEntity<List<StoreInfoResponseDto>> getStoreList(String storeCategoryName) {
-        List<Store> storeList = storeRepository.findAllByStoreCategory_StoreCategoryName(
-                storeCategoryName);
+        List<Store> storeList;
+        if (storeCategoryName.equals("전체")){
+            storeList = storeRepository.findAll();
+        } else {
+            storeList = storeRepository.findAllByStoreCategory_StoreCategoryName(storeCategoryName);
+        }
         List<StoreInfoResponseDto> storeInfoResponseDtoList = storeList.stream().map(StoreInfoResponseDto::new).toList();
         return new ResponseEntity<>(storeInfoResponseDtoList, HttpStatus.OK);
     }

--- a/src/main/java/com/example/foodorderplatform/util/UserValidator.java
+++ b/src/main/java/com/example/foodorderplatform/util/UserValidator.java
@@ -15,13 +15,23 @@ public class UserValidator {
     private static final List<UserRoleEnum>  managerUpperRoles = new ArrayList<>(List.of(MANAGER, ADMIN));
     private static final List<UserRoleEnum>  adminUpperRoles = new ArrayList<>(List.of(ADMIN));
 
-    public static boolean validateIsOwner(User user){
-      return ownerUpperRoles.contains(user.getRole());
+    // 가게 주인 검증
+    public static boolean validateIsStoreOwner(Store store, User user) {
+        return store.getUser().equals(user);
     }
 
-    public static boolean validateIsStoreOwner(Store store, User user) {
-        boolean first = store.getUser().equals(user);
-        boolean second = ownerUpperRoles.contains(user.getRole());
-        return store.getUser().equals(user) && ownerUpperRoles.contains(user.getRole());
+    // role이 owner 이상인지 검증
+    public static boolean validateRoleUpperOwner(User user){
+        return ownerUpperRoles.contains(user.getRole());
+    }
+
+    // role이 manager 이상인지 검증
+    public static boolean validateRoleUpperManager(User user){
+        return managerUpperRoles.contains(user.getRole());
+    }
+
+    // role이 admin 이상인지 검증
+    public static boolean validateRoleUpperAdmin(User user){
+        return adminUpperRoles.contains(user.getRole());
     }
 }


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - [ ] soft delete 미구현
  - [ ] XtoOne 컬럼 중 fetchType = lazy가 걸려 있지 않은 컬럼 존재
  - [ ] TimeStamped에 생성, 수정 유저 데이터가 바인딩되지 않음
  - [ ] 요청 시 인증/인가가 필요한 요청에 인증/인가가 없음.
  - [ ] 가게 조회 시 카테고리별 조회가 미구현

- **to-be**
  - [x] soft delete 구현
  - [x] 모든 XtoOne 컬럼에 fetchType을 Lazy로 변경
  - [x] 생성, 수정 시 사용자 이름이 TimeStamped에 반영되도록 추가(AuditorAwareImpl)
  - [x] 요청 시 인증/인가가 필요한 요청에 인증/인가 추가
  - [x] 가게 카테고리 추가, 조회 시 요청에 추가

## 코멘트
- soft delete의 경우 연관 관계에 있는 데이터들이 함께 delete 상태가 되도록 구현 필요